### PR TITLE
Update broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 This repository provides examples for running robots using Space ROS
 
-Please refer to the [dockerfile repo](https://github.com/space-ros/docker-images/tree/main/demo_spaceros) for running instruction
+Please refer to the [dockerfile repo](https://github.com/space-ros/docker/tree/main/space_robots) for running instruction


### PR DESCRIPTION
Update broken link, which changed in the target as part of space-ros/docker#29.

Fixes #14.