### PR TITLE
Fix canadarm's harcoded paths / update control interface / use xacro file

### DIFF
--- a/canadarm/config/canadarm_control.yaml
+++ b/canadarm/config/canadarm_control.yaml
@@ -3,7 +3,7 @@ controller_manager:
     update_rate: 100
 
     canadarm_joint_controller:
-      type: effort_controllers/JointGroupPositionController
+      type: position_controllers/JointGroupPositionController
 
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster

--- a/canadarm/launch/canadarm.launch.py
+++ b/canadarm/launch/canadarm.launch.py
@@ -30,7 +30,7 @@ def generate_launch_description():
     leo_model = os.path.join(canadarm_demos_path, 'worlds', 'simple.world')
 
 
-    doc = xacro.process_file(urdf_model_path)
+    doc = xacro.process_file(urdf_model_path, mappings={'xyz' : '1.0 0.0 1.5', 'rpy': '3.1416 0.0 0.0'})
     robot_description = {'robot_description': doc.toxml()}
 
 

--- a/canadarm/launch/canadarm.launch.py
+++ b/canadarm/launch/canadarm.launch.py
@@ -23,10 +23,10 @@ def generate_launch_description():
            ':'.join([environ.get('IGN_GAZEBO_SYSTEM_PLUGIN_PATH', default=''),
                      environ.get('LD_LIBRARY_PATH', default='')]),
            'IGN_GAZEBO_RESOURCE_PATH':
-           ':'.join([canadarm_demos_path])}
+           ':'.join([environ.get('IGN_GAZEBO_RESOURCE_PATH', default=''), canadarm_demos_path])}
 
 
-    urdf_model_path = os.path.join(simulation_models_path, 'models', 'canadarm', 'urdf', 'SSRMS_Canadarm2.urdf')
+    urdf_model_path = os.path.join(simulation_models_path, 'models', 'canadarm', 'urdf', 'SSRMS_Canadarm2.urdf.xacro')
     leo_model = os.path.join(canadarm_demos_path, 'worlds', 'simple.world')
 
 

--- a/canadarm/worlds/simple.world
+++ b/canadarm/worlds/simple.world
@@ -47,7 +47,7 @@
           <visual name='visual'>
             <geometry>
               <mesh>
-                <uri>/home/spaceros-user/demos_ws/install/simulation/share/simulation/models/canadarm/meshes/earth.dae</uri>
+                <uri>model://canadarm/meshes/earth.dae</uri>
                 <scale>3 3 3</scale>
               </mesh>
             </geometry>
@@ -77,7 +77,7 @@
         <visual name='visual'>
           <geometry>
             <mesh>
-              <uri>/home/spaceros-user/demos_ws/install/simulation/share/simulation/models/canadarm/meshes/iss.dae</uri>
+              <uri>model://canadarm/meshes/iss.dae</uri>
               <scale>1 1 1</scale>
             </mesh>
           </geometry>


### PR DESCRIPTION
Hi :). While trying to use the Canadarm, I ran into a few issues that were solved with the changes in this PR (plus this other [accompanying PR in the simulation package](https://github.com/space-ros/simulation/pull/9/files)). Changes are the following:

1. Use the canadarm's xacro file in the launch file
2. Change the type of controller from effort to position (JointGroupPositionController does exist in the position_controllers package).
3. Update simple.world to use model paths instead of hardcoded ones.

There is a video attached in the simulation's PR that shows the arm moving after using these changes. Tested in a ROS Humble environment. 