### PR TITLE
Add odometry node  and gz bridges for Nav2

### DIFF
--- a/mars_rover/CMakeLists.txt
+++ b/mars_rover/CMakeLists.txt
@@ -45,6 +45,7 @@ install(PROGRAMS
   nodes/move_mast
   nodes/move_wheel
   nodes/run_demo
+  nodes/odom_tf_publisher
   DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/mars_rover/nodes/odom_tf_publisher
+++ b/mars_rover/nodes/odom_tf_publisher
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+
+# adapted from ROS 2 tutorial
+# https://docs.ros.org/en/rolling/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Broadcaster-Py.html
+
+import rclpy
+
+from nav_msgs.msg import Odometry
+from geometry_msgs.msg import TransformStamped
+from rclpy.node import Node
+from tf2_ros import TransformBroadcaster
+
+class OdomTFBroadcaster(Node):
+
+    def __init__(self):
+        super().__init__('odom_tf_publisher')
+
+        # Initialize the transform broadcaster
+        self.tf_broadcaster = TransformBroadcaster(self)
+
+        # Subscribe to Odometry topic
+        # TODO: make the topic name a parameter instead of hard-coded
+        self.subscription = self.create_subscription(
+            Odometry,
+            f'/model/curiosity_mars_rover/odometry',
+            self.handle_odometry,
+            1)
+        self.subscription  # prevent unused variable warning
+
+    def handle_odometry(self, msg):
+        tf = TransformStamped()
+
+        # Read message content and assign it to
+        # corresponding tf variables
+        tf.header.stamp = msg.header.stamp
+        tf.header.frame_id = msg.header.frame_id
+        tf.child_frame_id = msg.child_frame_id
+
+        # get translation coordinates from the message pose
+        tf.transform.translation.x = msg.pose.pose.position.x
+        tf.transform.translation.y = msg.pose.pose.position.y
+        tf.transform.translation.z = msg.pose.pose.position.z
+
+        # get rotation from the message pose 
+        tf.transform.rotation.x = msg.pose.pose.orientation.x
+        tf.transform.rotation.y = msg.pose.pose.orientation.y
+        tf.transform.rotation.z = msg.pose.pose.orientation.z
+        tf.transform.rotation.w = msg.pose.pose.orientation.w
+        
+        # Send the transformation
+        self.tf_broadcaster.sendTransform(tf)
+
+
+def main():
+    rclpy.init()
+    node = OdomTFBroadcaster()
+    node.get_logger().info('Starting odometry_tf_publisher node')
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+
+    rclpy.shutdown()
+    
+if __name__ == '__main__':
+    main()

--- a/mars_rover/nodes/run_demo
+++ b/mars_rover/nodes/run_demo
@@ -20,6 +20,7 @@ class RunDemo(Node):
         self.stop_srv = self.create_service(Empty, 'move_stop', self.move_stop_callback)
         self.left_srv = self.create_service(Empty, 'turn_left', self.turn_left_callback)
         self.right_srv = self.create_service(Empty, 'turn_right', self.turn_right_callback)
+        self.stopped = True
 
         timer_period = 0.1
         self.timer = self.create_timer(timer_period, self.timer_callback)
@@ -27,33 +28,44 @@ class RunDemo(Node):
         self.curr_action = Twist()
 
     def timer_callback(self):
-        self.motion_publisher_.publish(self.curr_action)
+        if (not self.stopped):
+            self.motion_publisher_.publish(self.curr_action)
 
     def move_forward_callback(self, request, response):
+        self.get_logger().info("Moving forward")
         action = Twist()
         action.linear.x = 2.0
         self.curr_action = action
+        self.stopped = False
         return response
 
     def move_stop_callback(self, request, response):
+        # stop timer from publishing
+        self.stopped = True
+        self.get_logger().info("Stopping")
         self.curr_action = Twist()
+        # publish once to ensure we stop
+        self.motion_publisher_.publish(self.curr_action)
         return response
 
     def turn_left_callback(self, request, response):
+        self.get_logger().info("Turning left")
         action = Twist()
         action.linear.x = 1.0
         action.angular.z = 0.4
         self.curr_action = action
+        self.stopped = False
         return response
 
     def turn_right_callback(self, request, response):
+        self.get_logger().info("Turning right")
+        self.stopped = False
         action = Twist()
         action.linear.x = 1.0
         action.angular.z = -0.4
         self.curr_action = action
+        self.stopped = False
         return response
-
-    
 
 
 def main(args=None):


### PR DESCRIPTION
Adds odometry tf publisher node and gazebo to ROS bridges. Also adds ability to stop publishing /cmd_vel messages so that Nav2 controller can send them instead.

Of note - I noticed the python node files don't have a copyright header in them, so I followed that pattern in this repo. But should they have the standard OSRF header? If so I can add that.