### PR TITLE
Closes issue #82 - Updates for Gazebo Harmonic

### DIFF
--- a/canadarm2/Dockerfile
+++ b/canadarm2/Dockerfile
@@ -1,7 +1,7 @@
-FROM osrf/space-ros:humble-2024.10.0
+FROM osrf/space-ros:jazzy-2025.01.0
 
 ENV RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
-ENV ROS_DISTRO=humble
+ENV ROS_DISTRO=jazzy
 ENV HOME=/home/spaceros-user
 
 # Install dependencies

--- a/canadarm2/Dockerfile.GUI
+++ b/canadarm2/Dockerfile.GUI
@@ -1,13 +1,12 @@
-FROM ros:humble-ros-core-jammy
+FROM ros:jazzy-ros-core-noble
 
 ARG DEBIAN_FRONTEND=noninteractive
 
 ENV RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
-ENV ROS_DISTRO=humble
+ENV ROS_DISTRO=jazzy
 ENV USERNAME=spaceros-user
 ENV HOME=/home/spaceros-user
-ENV IGNITION_VERSION=fortress
-ENV GZ_VERSION=fortress
+ENV GZ_VERSION=harmonic
 
 # Install dependencies
 RUN apt update && apt install -y ros-${ROS_DISTRO}-rmw-cyclonedds-cpp \
@@ -23,9 +22,9 @@ RUN wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pk
 RUN apt-get update -qq \
     && apt-get install -y \
     gz-${GZ_VERSION} \
-    libgz-sim7 \
-    libgz-transport12 \
-    libgz-gui7 \
+    libgz-sim8 \
+    libgz-transport13 \
+    libgz-gui8 \
     build-essential\
     ros-${ROS_DISTRO}-rcl-interfaces\
     ros-${ROS_DISTRO}-rclcpp\
@@ -61,7 +60,7 @@ RUN apt update \
     && rosdep init \
     && rosdep update
 
-RUN . /opt/ros/humble/setup.sh \
+RUN . /opt/ros/jazzy/setup.sh \
     && cd ${HOME}/canadarm2_ws \
     && apt update \
     && rosdep install --from-paths src --ignore-src -r -y \
@@ -69,8 +68,8 @@ RUN . /opt/ros/humble/setup.sh \
 
 WORKDIR ${HOME}/canadarm2_ws
 
-RUN apt update && apt install -y ros-humble-ros-ign-gazebo
-RUN echo "source /opt/ros/humble/setup.bash" >> ${HOME}/.bashrc
+RUN apt update && apt install -y gz-harmonic
+RUN echo "source /opt/ros/jazzy/setup.bash" >> ${HOME}/.bashrc
 RUN echo "source ${HOME}/canadarm2_ws/install/setup.bash" >> ${HOME}/.bashrc
 
-CMD ign gazebo
+CMD gz sim

--- a/canadarm2/canadarm_demo/CMakeLists.txt
+++ b/canadarm2/canadarm_demo/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.22)
 project(canadarm_demo)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/canadarm2/canadarm_description/CMakeLists.txt
+++ b/canadarm2/canadarm_description/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.22)
 project(canadarm_description)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/canadarm2/canadarm_description/models/urdf/SSRMS_Canadarm2.gazebo.xacro
+++ b/canadarm2/canadarm_description/models/urdf/SSRMS_Canadarm2.gazebo.xacro
@@ -4,9 +4,9 @@
     <xacro:macro name="ssrms_canadarm2_gazebo" params="command_interface:=effort">
 
 
-        <ros2_control name="IgnitionSystem" type="system">
+        <ros2_control name="GazeboSystem" type="system">
             <hardware>
-                <plugin>ign_ros2_control/IgnitionSystem</plugin>
+                <plugin>gz_ros2_control/GazeboSimSystem</plugin>
             </hardware>
             <joint name="Base_Joint">
                 <command_interface name="${command_interface}"/>
@@ -53,7 +53,7 @@
         </ros2_control>
 
         <gazebo>
-            <plugin filename="libign_ros2_control-system" name="ign_ros2_control::IgnitionROS2ControlPlugin">
+            <plugin filename="gz_ros2_control-system" name="gz_ros2_control::GazeboSimROS2ControlPlugin">
                 <robot_param>robot_description</robot_param>
                 <robot_param_node>robot_state_publisher</robot_param_node>
                 <parameters>$(find canadarm_description)/models/config/canadarm_control.yaml</parameters>
@@ -69,3 +69,4 @@
     </xacro:macro>
 
 </robot>  
+

--- a/canadarm2/canadarm_description/models/urdf/SSRMS_Canadarm2.urdf.xacro
+++ b/canadarm2/canadarm_description/models/urdf/SSRMS_Canadarm2.urdf.xacro
@@ -36,13 +36,13 @@ The link CoM locations (with respect to link frame) are set to zero as the inert
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="$(find canadarm_description)/models/meshes/ee.dae" scale="1.0 1.0 1.0" />
+        <mesh filename="file://$(find canadarm_description)/models/meshes/ee.dae" scale="1.0 1.0 1.0" />
       </geometry>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="$(find canadarm_description)/models/meshes/ee.stl" scale="1.0 1.0 1.0" />
+        <mesh filename="file://$(find canadarm_description)/models/meshes/ee.stl" scale="1.0 1.0 1.0" />
       </geometry>
     </collision>
   </link>
@@ -70,13 +70,13 @@ The link CoM locations (with respect to link frame) are set to zero as the inert
     <visual>
       <origin rpy="0 -1.5708 0" xyz="0.25082 0 -0.175"/>
       <geometry>
-        <mesh filename="$(find canadarm_description)/models/meshes/joint_v3_0.dae" scale="1.0 1.0 1.0" />
+        <mesh filename="file://$(find canadarm_description)/models/meshes/joint_v3_0.dae" scale="1.0 1.0 1.0" />
       </geometry>
     </visual>
     <collision>
       <origin rpy="0 -1.5708 0" xyz="0.25082 0 -0.175"/>
       <geometry>
-        <mesh filename="$(find canadarm_description)/models/meshes/joint_v3_0.stl" scale="1.0 1.0 1.0" />
+        <mesh filename="file://$(find canadarm_description)/models/meshes/joint_v3_0.stl" scale="1.0 1.0 1.0" />
       </geometry>
     </collision>
   </link>
@@ -101,13 +101,13 @@ The link CoM locations (with respect to link frame) are set to zero as the inert
     <visual>
       <origin rpy="0 0 0" xyz="0.175 0 -0.25082"/>
       <geometry>
-        <mesh filename="$(find canadarm_description)/models/meshes/joint_v3_0.dae" scale="1.0 1.0 1.0" />
+        <mesh filename="file://$(find canadarm_description)/models/meshes/joint_v3_0.dae" scale="1.0 1.0 1.0" />
       </geometry>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0.175 0 -0.25082"/>
       <geometry>
-        <mesh filename="$(find canadarm_description)/models/meshes/joint_v3_0.stl" scale="1.0 1.0 1.0" />
+        <mesh filename="file://$(find canadarm_description)/models/meshes/joint_v3_0.stl" scale="1.0 1.0 1.0" />
       </geometry>
     </collision>
   </link>
@@ -133,39 +133,39 @@ The link CoM locations (with respect to link frame) are set to zero as the inert
     <visual>
       <origin rpy="0 -1.5708 0" xyz="0.25082 0 -0.175"/>
       <geometry>
-        <mesh filename="$(find canadarm_description)/models/meshes/joint_v3_0.dae" scale="1.0 1.0 1.0" />
+        <mesh filename="file://$(find canadarm_description)/models/meshes/joint_v3_0.dae" scale="1.0 1.0 1.0" />
       </geometry>
     </visual>
     <collision>
       <origin rpy="0 -1.5708 0" xyz="0.25082 0 -0.175"/>
       <geometry>
-        <mesh filename="$(find canadarm_description)/models/meshes/joint_v3_0.stl" scale="1.0 1.0 1.0" />
+        <mesh filename="file://$(find canadarm_description)/models/meshes/joint_v3_0.stl" scale="1.0 1.0 1.0" />
       </geometry>
     </collision>
 
     <visual>
       <origin rpy="-1.5708 0 -1.5708" xyz="0.25082 0 -0.175"/>
       <geometry>
-        <mesh filename="$(find canadarm_description)/models/meshes/long_link_1_v3_0.dae" scale="1.0 1.0 1.0" />
+        <mesh filename="file://$(find canadarm_description)/models/meshes/long_link_1_v3_0.dae" scale="1.0 1.0 1.0" />
       </geometry>
     </visual>
     <collision>
       <origin rpy="-1.5708 0 -1.5708" xyz="0.25082 0 -0.175"/>
       <geometry>
-        <mesh filename="$(find canadarm_description)/models/meshes/long_link_1_v3_0.stl" scale="1.0 1.0 1.0" />
+        <mesh filename="file://$(find canadarm_description)/models/meshes/long_link_1_v3_0.stl" scale="1.0 1.0 1.0" />
       </geometry>
     </collision>
 
     <visual>
       <origin rpy="0 1.5708 0" xyz="7.36082 0 -0.175"/>
       <geometry>
-        <mesh filename="$(find canadarm_description)/models/meshes/joint_v3_0.dae" scale="1.0 1.0 1.0" />
+        <mesh filename="file://$(find canadarm_description)/models/meshes/joint_v3_0.dae" scale="1.0 1.0 1.0" />
       </geometry>
     </visual>
     <collision>
       <origin rpy="0 1.5708 0" xyz="7.36082 0 -0.175"/>
       <geometry>
-        <mesh filename="$(find canadarm_description)/models/meshes/joint_v3_0.stl" scale="1.0 1.0 1.0" />
+        <mesh filename="file://$(find canadarm_description)/models/meshes/joint_v3_0.stl" scale="1.0 1.0 1.0" />
       </geometry>
     </collision>
 
@@ -199,39 +199,39 @@ The link CoM locations (with respect to link frame) are set to zero as the inert
     <visual>
       <origin rpy="0 1.5708 0" xyz="-0.25082 0 -0.175"/>
       <geometry>
-        <mesh filename="$(find canadarm_description)/models/meshes/link_joint_v2_1.dae" scale="1.0 1.0 1.0" />
+        <mesh filename="file://$(find canadarm_description)/models/meshes/link_joint_v2_1.dae" scale="1.0 1.0 1.0" />
       </geometry>
     </visual>
     <collision>
       <origin rpy="0 1.5708 0" xyz="-0.25082 0 -0.175"/>
       <geometry>
-        <mesh filename="$(find canadarm_description)/models/meshes/link_joint_v2_1.stl" scale="1.0 1.0 1.0" />
+        <mesh filename="file://$(find canadarm_description)/models/meshes/link_joint_v2_1.stl" scale="1.0 1.0 1.0" />
       </geometry>
     </collision>
 
     <visual>
       <origin rpy="1.57 -3.14 1.57" xyz="-7.36082 0 -0.175"/>
       <geometry>
-        <mesh filename="$(find canadarm_description)/models/meshes/long_link_2_v3_0.dae" scale="1.0 1.0 1.0" />
+        <mesh filename="file://$(find canadarm_description)/models/meshes/long_link_2_v3_0.dae" scale="1.0 1.0 1.0" />
       </geometry>
     </visual>
     <collision>
       <origin rpy="1.57 -3.14 1.57" xyz="-7.36082 0 -0.175"/>
       <geometry>
-        <mesh filename="$(find canadarm_description)/models/meshes/long_link_2_v3_0.stl" scale="1.0 1.0 1.0" />
+        <mesh filename="file://$(find canadarm_description)/models/meshes/long_link_2_v3_0.stl" scale="1.0 1.0 1.0" />
       </geometry>
     </collision>
 
     <visual>
       <origin rpy="0 -1.57 0" xyz="-7.36082 0 -0.175"/>
       <geometry>
-        <mesh filename="$(find canadarm_description)/models/meshes/joint_v3_0.dae" scale="1.0 1.0 1.0" />
+        <mesh filename="file://$(find canadarm_description)/models/meshes/joint_v3_0.dae" scale="1.0 1.0 1.0" />
       </geometry>
     </visual>
     <collision>
       <origin rpy="0 -1.57 0" xyz="-7.36082 0 -0.175"/>
       <geometry>
-        <mesh filename="$(find canadarm_description)/models/meshes/joint_v3_0.stl" scale="1.0 1.0 1.0" />
+        <mesh filename="file://$(find canadarm_description)/models/meshes/joint_v3_0.stl" scale="1.0 1.0 1.0" />
       </geometry>
     </collision>
 
@@ -258,13 +258,13 @@ The link CoM locations (with respect to link frame) are set to zero as the inert
     <visual>
       <origin rpy="0 -3.14 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="$(find canadarm_description)/models/meshes/joint_v3_0.dae" scale="1.0 1.0 1.0" />
+        <mesh filename="file://$(find canadarm_description)/models/meshes/joint_v3_0.dae" scale="1.0 1.0 1.0" />
       </geometry>
     </visual>
     <collision>
       <origin rpy="0 -3.14 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="$(find canadarm_description)/models/meshes/joint_v3_0.stl" scale="1.0 1.0 1.0" />
+        <mesh filename="file://$(find canadarm_description)/models/meshes/joint_v3_0.stl" scale="1.0 1.0 1.0" />
       </geometry>
     </collision>
   </link>
@@ -290,13 +290,13 @@ The link CoM locations (with respect to link frame) are set to zero as the inert
     <visual>
       <origin rpy="0 -1.5708 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="$(find canadarm_description)/models/meshes/joint_v3_0.dae" scale="1.0 1.0 1.0" />
+        <mesh filename="file://$(find canadarm_description)/models/meshes/joint_v3_0.dae" scale="1.0 1.0 1.0" />
       </geometry>
     </visual>
     <collision>
       <origin rpy="0 -1.5708 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="$(find canadarm_description)/models/meshes/joint_v3_0.stl" scale="1.0 1.0 1.0" />
+        <mesh filename="file://$(find canadarm_description)/models/meshes/joint_v3_0.stl" scale="1.0 1.0 1.0" />
       </geometry>
     </collision>
 
@@ -323,13 +323,13 @@ The link CoM locations (with respect to link frame) are set to zero as the inert
     <visual>
       <origin rpy="0 -3.1415 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="$(find canadarm_description)/models/meshes/ee.dae" scale="1.0 1.0 1.0" />
+        <mesh filename="file://$(find canadarm_description)/models/meshes/ee.dae" scale="1.0 1.0 1.0" />
       </geometry>
     </visual>
     <collision>
       <origin rpy="0 -3.1415 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="$(find canadarm_description)/models/meshes/ee.stl" scale="1.0 1.0 1.0" />
+        <mesh filename="file://$(find canadarm_description)/models/meshes/ee.stl" scale="1.0 1.0 1.0" />
       </geometry>
     </collision>
 
@@ -337,3 +337,4 @@ The link CoM locations (with respect to link frame) are set to zero as the inert
 
 
 </robot>
+

--- a/canadarm2/canadarm_gazebo/CMakeLists.txt
+++ b/canadarm2/canadarm_gazebo/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.22)
 project(canadarm_gazebo)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/canadarm2/canadarm_gazebo/package.xml
+++ b/canadarm2/canadarm_gazebo/package.xml
@@ -11,7 +11,7 @@
   <depend>canadarm_description</depend>
   <depend>ros_gz</depend>
 
-  <exec_depend>ign_ros2_control</exec_depend>
+  <exec_depend>gz_ros2_control</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>control_msgs</exec_depend>

--- a/canadarm2/canadarm_gazebo/worlds/simple.world
+++ b/canadarm2/canadarm_gazebo/worlds/simple.world
@@ -1,18 +1,74 @@
-<sdf version="1.5">
+<sdf version="1.8">
   <world name="default">
-    <gui fullscreen="0">
 
-      <plugin filename="GzScene3D" name="3D View">
-        <ignition-gui>
+    <scene>
+      <ambient>0.4 0.4 0.4 1</ambient>
+      <background>0.0 0.0 0.0 1</background>
+      <grid>false</grid>
+    </scene>   
+
+    <gui fullscreen="0">
+ 
+      <!-- 3D scene -->
+      <plugin filename="MinimalScene" name="3D View">
+        <gz-gui>
           <title>3D View</title>
           <property type="bool" key="showTitleBar">true</property>
           <property type="string" key="state">docked</property>
-        </ignition-gui>
+        </gz-gui>
+ 
         <engine>ogre2</engine>
         <scene>scene</scene>
-        <background_color>0.0 0.0 0.0</background_color>
+        <camera_pose>-10.0 -12 8.0 0 0.5 0.3</camera_pose>
       </plugin>
+      <plugin filename="GzSceneManager" name="Scene Manager">
+        <gz-gui>
+          <property key="resizable" type="bool">false</property>
+          <property key="width" type="double">5</property>
+          <property key="height" type="double">5</property>
+          <property key="state" type="string">floating</property>
+          <property key="showTitleBar" type="bool">false</property>
+        </gz-gui>
+      </plugin>
+      <plugin filename="InteractiveViewControl" name="Interactive view control">
+        <gz-gui>
+          <property key="resizable" type="bool">false</property>
+          <property key="width" type="double">5</property>
+          <property key="height" type="double">5</property>
+          <property key="state" type="string">floating</property>
+          <property key="showTitleBar" type="bool">false</property>
+        </gz-gui>
+      </plugin>
+ 
     </gui>
+
+    <physics name='default_physics' default='1' type='ignored'>
+      <max_step_size>0.01</max_step_size>
+      <real_time_factor>1</real_time_factor>
+      <real_time_update_rate>100</real_time_update_rate>
+    </physics>
+
+    <plugin
+      filename="gz-sim-physics-system"
+      name="gz::sim::systems::Physics">
+    </plugin>
+
+    <plugin
+      filename="gz-sim-user-commands-system"
+      name="gz::sim::systems::UserCommands">
+    </plugin>
+
+    <plugin
+      filename="gz-sim-scene-broadcaster-system"
+      name="gz::sim::systems::SceneBroadcaster">
+    </plugin> 
+
+    <plugin
+      filename="gz-sim-sensors-system"
+      name="gz::sim::systems::Sensors">
+      <render_engine>ogre2</render_engine>
+    </plugin>
+
 
     <light type="directional" name="sun">
       <cast_shadows>true</cast_shadows>
@@ -91,5 +147,8 @@
         <gravity>0</gravity>
       </link>
     </model>
+
   </world>
+   
 </sdf>
+

--- a/canadarm2/docker-compose.yml
+++ b/canadarm2/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       [
         "bash",
         "-c",
-        "source /opt/ros/humble/setup.bash && source ~/canadarm2_ws/install/setup.bash && ros2 launch canadarm_gazebo canadarm.launch.py",
+        "source /opt/ros/jazzy/setup.bash && source ~/canadarm2_ws/install/setup.bash && ros2 launch canadarm_gazebo canadarm.launch.py",
       ]
     network_mode: host
     privileged: true # for UI

--- a/curiosity_rover/Dockerfile
+++ b/curiosity_rover/Dockerfile
@@ -1,7 +1,7 @@
-FROM osrf/space-ros:humble-2024.10.0
+FROM osrf/space-ros:jazzy-2025.01.0
 
 ENV RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
-ENV ROS_DISTRO=humble
+ENV ROS_DISTRO=jazzy
 ENV HOME=/home/spaceros-user
 
 # Install dependencies

--- a/curiosity_rover/Dockerfile.GUI
+++ b/curiosity_rover/Dockerfile.GUI
@@ -1,13 +1,12 @@
-FROM ros:humble-ros-core-jammy
+FROM ros:jazzy-ros-core-noble
 
 ARG DEBIAN_FRONTEND=noninteractive
 
 ENV RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
-ENV ROS_DISTRO=humble
+ENV ROS_DISTRO=jazzy
 ENV USERNAME=spaceros-user
 ENV HOME=/home/spaceros-user
-ENV IGNITION_VERSION=fortress
-ENV GZ_VERSION=fortress
+ENV GZ_VERSION=harmonic
 
 # Install dependencies
 RUN apt update && apt install -y ros-${ROS_DISTRO}-rmw-cyclonedds-cpp \
@@ -23,9 +22,9 @@ RUN wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pk
 RUN apt-get update -qq \
     && apt-get install -y \
     gz-${GZ_VERSION} \
-    libgz-sim7 \
-    libgz-transport12 \
-    libgz-gui7 \
+    libgz-sim8 \
+    libgz-transport13 \
+    libgz-gui8 \
     build-essential\
     ros-${ROS_DISTRO}-rcl-interfaces\
     ros-${ROS_DISTRO}-rclcpp\
@@ -61,7 +60,7 @@ RUN apt update \
     && rosdep init \
     && rosdep update
 
-RUN . /opt/ros/humble/setup.sh \
+RUN . /opt/ros/jazzy/setup.sh \
     && cd ${HOME}/curiosity_ws \
     && apt update \
     && rosdep install --from-paths src --ignore-src -r -y \
@@ -69,8 +68,8 @@ RUN . /opt/ros/humble/setup.sh \
 
 WORKDIR ${HOME}/curiosity_ws
 
-RUN apt update && apt install -y ros-humble-ros-ign-gazebo
-RUN echo "source /opt/ros/humble/setup.bash" >> ${HOME}/.bashrc
+RUN apt update && apt install -y gz-harmonic
+RUN echo "source /opt/ros/jazzy/setup.bash" >> ${HOME}/.bashrc
 RUN echo "source ${HOME}/curiosity_ws/install/setup.bash" >> ${HOME}/.bashrc
 
-CMD ign gazebo
+CMD gz sim

--- a/curiosity_rover/curiosity_description/CMakeLists.txt
+++ b/curiosity_rover/curiosity_description/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.22)
 project(curiosity_description)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/curiosity_rover/curiosity_description/models/config/mars_rover_control.yaml
+++ b/curiosity_rover/curiosity_description/models/config/mars_rover_control.yaml
@@ -15,7 +15,7 @@ controller_manager:
       type: joint_trajectory_controller/JointTrajectoryController
 
     wheel_tree_position_controller:
-      type: effort_controllers/JointGroupPositionController
+      type: effort_controllers/JointGroupEffortController
 
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster

--- a/curiosity_rover/curiosity_description/models/urdf/arm.xacro
+++ b/curiosity_rover/curiosity_description/models/urdf/arm.xacro
@@ -34,14 +34,14 @@
 			<collision>
 				<origin xyz="0 0 0" rpy="0 0 0"/>
 				<geometry>
-					<mesh filename="$(find curiosity_description)/models/meshes/arm_01_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+					<mesh filename="file://$(find curiosity_description)/models/meshes/arm_01_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 				</geometry>
 			</collision>
 
 			<visual>
 				<origin xyz="0 0 0" rpy="0 0 0"/>
 				<geometry>
-					<mesh filename="$(find curiosity_description)/models/meshes/arm_01_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+					<mesh filename="file://$(find curiosity_description)/models/meshes/arm_01_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 				</geometry>
 			</visual>
 
@@ -105,14 +105,14 @@
 			<collision>
 				<origin xyz="0 0 0" rpy="0 0 0"/>
 				<geometry>
-					<mesh filename="$(find curiosity_description)/models/meshes/arm_01_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+					<mesh filename="file://$(find curiosity_description)/models/meshes/arm_01_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 				</geometry>
 			</collision>
 
 			<visual>
 				<origin xyz="0 0 0" rpy="0 0 0"/>
 				<geometry>
-					<mesh filename="$(find curiosity_description)/models/meshes/arm_02_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+					<mesh filename="file://$(find curiosity_description)/models/meshes/arm_02_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 				</geometry>
 			</visual>
 
@@ -176,14 +176,14 @@
 			<collision>
 				<origin xyz="0 0 0" rpy="0 0 0"/>
 				<geometry>
-					<mesh filename="$(find curiosity_description)/models/meshes/arm_03_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+					<mesh filename="file://$(find curiosity_description)/models/meshes/arm_03_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 				</geometry>
 			</collision>
 
 			<visual>
 				<origin xyz="0 0 0" rpy="0 0 0"/>
 				<geometry>
-					<mesh filename="$(find curiosity_description)/models/meshes/arm_03_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+					<mesh filename="file://$(find curiosity_description)/models/meshes/arm_03_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 				</geometry>
 			</visual>
 
@@ -248,14 +248,14 @@
 			<collision>
 				<origin xyz="0 0 0" rpy="0 0 0"/>
 				<geometry>
-					<mesh filename="$(find curiosity_description)/models/meshes/arm_04_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+					<mesh filename="file://$(find curiosity_description)/models/meshes/arm_04_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 				</geometry>
 			</collision>
 
 			<visual>
 				<origin xyz="0 0 0" rpy="0 0 0"/>
 				<geometry>
-					<mesh filename="$(find curiosity_description)/models/meshes/arm_04_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+					<mesh filename="file://$(find curiosity_description)/models/meshes/arm_04_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 				</geometry>
 			</visual>
 
@@ -320,14 +320,14 @@
 			<collision>
 				<origin xyz="0 0 0" rpy="0 0 0"/>
 				<geometry>
-					<mesh filename="$(find curiosity_description)/models/meshes/arm_tools_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+					<mesh filename="file://$(find curiosity_description)/models/meshes/arm_tools_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 				</geometry>
 			</collision>
 
 			<visual>
 				<origin xyz="0 0 0" rpy="0 0 0"/>
 				<geometry>
-					<mesh filename="$(find curiosity_description)/models/meshes/arm_tools_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+					<mesh filename="file://$(find curiosity_description)/models/meshes/arm_tools_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 				</geometry>
 			</visual>
 

--- a/curiosity_rover/curiosity_description/models/urdf/chassis.xacro
+++ b/curiosity_rover/curiosity_description/models/urdf/chassis.xacro
@@ -24,14 +24,14 @@
 			<collision>
 				<origin xyz="0 0 0" rpy="0 0 0"/>
 				<geometry>
-					<mesh filename="$(find curiosity_description)/models/meshes/chassis_full_fixed_glitch_v2.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+					<mesh filename="file://$(find curiosity_description)/models/meshes/chassis_full_fixed_glitch_v2.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 				</geometry>
 			</collision>
 
 			<visual>
 				<origin xyz="0 0 0" rpy="0 0 0"/>
 				<geometry>
-					<mesh filename="$(find curiosity_description)/models/meshes/chassis_full_fixed_glitch_v2.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+					<mesh filename="file://$(find curiosity_description)/models/meshes/chassis_full_fixed_glitch_v2.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 				</geometry>
 			</visual>
 

--- a/curiosity_rover/curiosity_description/models/urdf/curiosity_mars_rover.gazebo
+++ b/curiosity_rover/curiosity_description/models/urdf/curiosity_mars_rover.gazebo
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://wiki.ros.org/xacro">
 
-  <ros2_control name="IgnitionSystem" type="system">
+  <ros2_control name="GazeboSystem" type="system">
     <hardware>
-      <plugin>ign_ros2_control/IgnitionSystem</plugin>
+      <plugin>gz_ros2_control/GazeboSimSystem</plugin>
     </hardware>
     <!-- Arm Joints Interfaces-->
     <joint name="arm_01_joint">
@@ -132,19 +132,19 @@
   </ros2_control>
 
   <gazebo>
-    <plugin filename="libign_ros2_control-system" name="ign_ros2_control::IgnitionROS2ControlPlugin">
+    <plugin filename="gz_ros2_control-system" name="gz_ros2_control::GazeboSimROS2ControlPlugin">
       <robot_param>robot_description</robot_param>
       <robot_param_node>robot_state_publisher</robot_param_node>
       <parameters>$(find curiosity_description)/models/config/mars_rover_control.yaml</parameters>
     </plugin>
 
-    <plugin filename="ignition-gazebo-odometry-publisher-system" name="ignition::gazebo::systems::OdometryPublisher">
+    <plugin filename="gz-sim-odometry-publisher-system" name="gz::sim::systems::OdometryPublisher">
       <odom_frame>/odom</odom_frame>
       <robot_base_frame>/base_footprint</robot_base_frame>
       <odom_publish_frequency>10</odom_publish_frequency>
     </plugin>
 
-    <plugin filename="ignition-gazebo-sensors-system" name="ignition::gazebo::systems::Sensors">
+    <plugin filename="gz-sim-sensors-system" name="gz::sim::systems::Sensors">
       <render_engine>ogre2</render_engine>
       <background_color>0.9 0.753 0.66 1</background_color>
     </plugin>
@@ -152,7 +152,7 @@
 
   <gazebo reference="lidar_link">
     <sensor name='lidar' type='gpu_lidar'>"
-      <ignition_frame_id>lidar_link</ignition_frame_id>
+      <gz_frame_id>lidar_link</gz_frame_id>
       <pose relative_to='lidar_link'>0 0 0 0 0 0</pose>
       <topic>scan</topic>
       <update_rate>10</update_rate>
@@ -319,3 +319,4 @@
   </gazebo>
 
 </robot>
+

--- a/curiosity_rover/curiosity_description/models/urdf/left_wheel_group.xacro
+++ b/curiosity_rover/curiosity_description/models/urdf/left_wheel_group.xacro
@@ -8,14 +8,14 @@
 			<collision>
 				<origin xyz="0 0 0" rpy="0 0 0"/>
 				<geometry>
-					<mesh filename="$(find curiosity_description)/models/meshes/left_axis_jointfix_v2.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+					<mesh filename="file://$(find curiosity_description)/models/meshes/left_axis_jointfix_v2.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 				</geometry>
 			</collision>
 
 			<visual>
 				<origin xyz="0 0 0" rpy="0 0 0"/>
 				<geometry>
-					<mesh filename="$(find curiosity_description)/models/meshes/left_axis_jointfix_v2.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+					<mesh filename="file://$(find curiosity_description)/models/meshes/left_axis_jointfix_v2.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 				</geometry>
 			</visual>
 
@@ -38,14 +38,14 @@
 			<collision>
 				<origin xyz="0 0 0" rpy="0 0 0"/>
 				<geometry>
-					<mesh filename="$(find curiosity_description)/models/meshes/suspension_arm_F_L_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+					<mesh filename="file://$(find curiosity_description)/models/meshes/suspension_arm_F_L_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 				</geometry>
 			</collision>
 
 			<visual>
 				<origin xyz="0 0 0" rpy="0 0 0"/>
 				<geometry>
-					<mesh filename="$(find curiosity_description)/models/meshes/suspension_arm_F_L_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+					<mesh filename="file://$(find curiosity_description)/models/meshes/suspension_arm_F_L_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 				</geometry>
 			</visual>
 
@@ -80,14 +80,14 @@
 			<collision>
 				<origin xyz="0 0 0" rpy="0 0 0"/>
 				<geometry>
-					<mesh filename="$(find curiosity_description)/models/meshes/suspension_arm_B_L_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+					<mesh filename="file://$(find curiosity_description)/models/meshes/suspension_arm_B_L_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 				</geometry>
 			</collision>
 
 			<visual>
 				<origin xyz="0 0 0" rpy="0 0 0"/>
 				<geometry>
-					<mesh filename="$(find curiosity_description)/models/meshes/suspension_arm_B_L_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+					<mesh filename="file://$(find curiosity_description)/models/meshes/suspension_arm_B_L_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 				</geometry>
 			</visual>
 
@@ -150,14 +150,14 @@
 			<collision>
 				<origin xyz="0 0 0" rpy="0 0 0"/>
 				<geometry>
-					<mesh filename="$(find curiosity_description)/models/meshes/suspension_arm_B2_L_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+					<mesh filename="file://$(find curiosity_description)/models/meshes/suspension_arm_B2_L_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 				</geometry>
 			</collision>
 
 			<visual>
 				<origin xyz="0 0 0" rpy="0 0 0"/>
 				<geometry>
-					<mesh filename="$(find curiosity_description)/models/meshes/suspension_arm_B2_L_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+					<mesh filename="file://$(find curiosity_description)/models/meshes/suspension_arm_B2_L_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 				</geometry>
 			</visual>
 
@@ -221,14 +221,14 @@
 			<collision>
 				<origin xyz="0 0 0" rpy="0 0 0"/>
 				<geometry>
-					<mesh filename="$(find curiosity_description)/models/meshes/suspension_steer_F_L_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+					<mesh filename="file://$(find curiosity_description)/models/meshes/suspension_steer_F_L_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 				</geometry>
 			</collision>
 
 			<visual>
 				<origin xyz="0 0 0" rpy="0 0 0"/>
 				<geometry>
-					<mesh filename="$(find curiosity_description)/models/meshes/suspension_steer_F_L_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+					<mesh filename="file://$(find curiosity_description)/models/meshes/suspension_steer_F_L_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 				</geometry>
 			</visual>
 
@@ -356,14 +356,14 @@
 			<collision>
 				<origin xyz="0 0 0" rpy="0 0 0"/>
 				<geometry>
-					<mesh filename="$(find curiosity_description)/models/meshes/suspension_steer_B_L_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+					<mesh filename="file://$(find curiosity_description)/models/meshes/suspension_steer_B_L_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 				</geometry>
 			</collision>
 
 			<visual>
 				<origin xyz="0 0 0" rpy="0 0 0"/>
 				<geometry>
-					<mesh filename="$(find curiosity_description)/models/meshes/suspension_steer_B_L_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+					<mesh filename="file://$(find curiosity_description)/models/meshes/suspension_steer_B_L_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 				</geometry>
 			</visual>
 

--- a/curiosity_rover/curiosity_description/models/urdf/right_wheel_group.xacro
+++ b/curiosity_rover/curiosity_description/models/urdf/right_wheel_group.xacro
@@ -7,14 +7,14 @@
 			<collision>
 				<origin xyz="0 0 0" rpy="0 0 0"/>
 				<geometry>
-					<mesh filename="$(find curiosity_description)/models/meshes/right_axis_jointfix_v2.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+					<mesh filename="file://$(find curiosity_description)/models/meshes/right_axis_jointfix_v2.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 				</geometry>
 			</collision>
 
 			<visual>
 				<origin xyz="0 0 0" rpy="0 0 0"/>
 				<geometry>
-					<mesh filename="$(find curiosity_description)/models/meshes/right_axis_jointfix_v2.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+					<mesh filename="file://$(find curiosity_description)/models/meshes/right_axis_jointfix_v2.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 				</geometry>
 			</visual>
 
@@ -36,14 +36,14 @@
 			<collision>
 				<origin xyz="0 0 0" rpy="0 0 0"/>
 				<geometry>
-					<mesh filename="$(find curiosity_description)/models/meshes/suspension_arm_F_R_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+					<mesh filename="file://$(find curiosity_description)/models/meshes/suspension_arm_F_R_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 				</geometry>
 			</collision>
 
 			<visual>
 				<origin xyz="0 0 0" rpy="0 0 0"/>
 				<geometry>
-					<mesh filename="$(find curiosity_description)/models/meshes/suspension_arm_F_R_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+					<mesh filename="file://$(find curiosity_description)/models/meshes/suspension_arm_F_R_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 				</geometry>
 			</visual>
 
@@ -80,14 +80,14 @@
 			<collision>
 				<origin xyz="0 0 0" rpy="0 0 0"/>
 				<geometry>
-					<mesh filename="$(find curiosity_description)/models/meshes/suspension_arm_B_R_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+					<mesh filename="file://$(find curiosity_description)/models/meshes/suspension_arm_B_R_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 				</geometry>
 			</collision>
 
 			<visual>
 				<origin xyz="0 0 0" rpy="0 0 0"/>
 				<geometry>
-					<mesh filename="$(find curiosity_description)/models/meshes/suspension_arm_B_R_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+					<mesh filename="file://$(find curiosity_description)/models/meshes/suspension_arm_B_R_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 				</geometry>
 			</visual>
 
@@ -150,14 +150,14 @@
 			<collision>
 				<origin xyz="0 0 0" rpy="0 0 0"/>
 				<geometry>
-					<mesh filename="$(find curiosity_description)/models/meshes/suspension_arm_B2_R_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+					<mesh filename="file://$(find curiosity_description)/models/meshes/suspension_arm_B2_R_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 				</geometry>
 			</collision>
 
 			<visual>
 				<origin xyz="0 0 0" rpy="0 0 0"/>
 				<geometry>
-					<mesh filename="$(find curiosity_description)/models/meshes/suspension_arm_B2_R_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+					<mesh filename="file://$(find curiosity_description)/models/meshes/suspension_arm_B2_R_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 				</geometry>
 			</visual>
 
@@ -222,14 +222,14 @@
 			<collision>
 				<origin xyz="0 0 0" rpy="0 0 0"/>
 				<geometry>
-					<mesh filename="$(find curiosity_description)/models/meshes/suspension_steer_F_R_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+					<mesh filename="file://$(find curiosity_description)/models/meshes/suspension_steer_F_R_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 				</geometry>
 			</collision>
 
 			<visual>
 				<origin xyz="0 0 0" rpy="0 0 0"/>
 				<geometry>
-					<mesh filename="$(find curiosity_description)/models/meshes/suspension_steer_F_R_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+					<mesh filename="file://$(find curiosity_description)/models/meshes/suspension_steer_F_R_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 				</geometry>
 			</visual>
 
@@ -352,14 +352,14 @@
 			<collision>
 				<origin xyz="0 0 0" rpy="0 0 0"/>
 				<geometry>
-					<mesh filename="$(find curiosity_description)/models/meshes/suspension_steer_B_R_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+					<mesh filename="file://$(find curiosity_description)/models/meshes/suspension_steer_B_R_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 				</geometry>
 			</collision>
 
 			<visual>
 				<origin xyz="0 0 0" rpy="0 0 0"/>
 				<geometry>
-					<mesh filename="$(find curiosity_description)/models/meshes/suspension_steer_B_R_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+					<mesh filename="file://$(find curiosity_description)/models/meshes/suspension_steer_B_R_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 				</geometry>
 			</visual>
 

--- a/curiosity_rover/curiosity_description/models/urdf/sensor_mast.xacro
+++ b/curiosity_rover/curiosity_description/models/urdf/sensor_mast.xacro
@@ -34,14 +34,14 @@
 			<collision>
 				<origin xyz="0 0 0" rpy="0 0 0"/>
 				<geometry>
-					<mesh filename="$(find curiosity_description)/models/meshes/mast_p_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+					<mesh filename="file://$(find curiosity_description)/models/meshes/mast_p_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 				</geometry>
 			</collision>
 
 			<visual>
 				<origin xyz="0 0 0" rpy="0 0 0"/>
 				<geometry>
-					<mesh filename="$(find curiosity_description)/models/meshes/mast_p_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+					<mesh filename="file://$(find curiosity_description)/models/meshes/mast_p_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 				</geometry>
 			</visual>
 
@@ -105,14 +105,14 @@
 			<collision>
 				<origin xyz="0 0 0" rpy="0 0 0"/>
 				<geometry>
-					<mesh filename="$(find curiosity_description)/models/meshes/mast_02_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+					<mesh filename="file://$(find curiosity_description)/models/meshes/mast_02_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 				</geometry>
 			</collision>
 
 			<visual>
 				<origin xyz="0 0 0" rpy="0 0 0"/>
 				<geometry>
-					<mesh filename="$(find curiosity_description)/models/meshes/mast_02_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+					<mesh filename="file://$(find curiosity_description)/models/meshes/mast_02_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 				</geometry>
 			</visual>
 
@@ -177,14 +177,14 @@
 			<collision>
 				<origin xyz="0 0 0" rpy="0 0 0"/>
 				<geometry>
-					<mesh filename="$(find curiosity_description)/models/meshes/mast_cameras.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+					<mesh filename="file://$(find curiosity_description)/models/meshes/mast_cameras.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 				</geometry>
 			</collision>
 
 			<visual>
 				<origin xyz="0 0 0" rpy="0 0 0"/>
 				<geometry>
-					<mesh filename="$(find curiosity_description)/models/meshes/mast_cameras.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+					<mesh filename="file://$(find curiosity_description)/models/meshes/mast_cameras.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 				</geometry>
 			</visual>
 

--- a/curiosity_rover/curiosity_description/models/urdf/wheel.xacro
+++ b/curiosity_rover/curiosity_description/models/urdf/wheel.xacro
@@ -14,7 +14,7 @@
 			<visual>
 				<origin xyz="0 0 0" rpy="0 0 0"/>
 				<geometry>
-					<mesh filename="$(find curiosity_description)/models/meshes/wheel_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+					<mesh filename="file://$(find curiosity_description)/models/meshes/wheel_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 				</geometry>
 			</visual>
 

--- a/curiosity_rover/curiosity_gazebo/CMakeLists.txt
+++ b/curiosity_rover/curiosity_gazebo/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.22)
 project(curiosity_gazebo)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/curiosity_rover/curiosity_gazebo/package.xml
+++ b/curiosity_rover/curiosity_gazebo/package.xml
@@ -16,7 +16,7 @@
   <depend>ament_cmake_python</depend>
   <depend>ros_gz</depend>
 
-  <exec_depend>ign_ros2_control</exec_depend>
+  <exec_depend>gz_ros2_control</exec_depend>
   <exec_depend>ros2_control</exec_depend>
   <exec_depend>ros2_controllers</exec_depend>
 

--- a/curiosity_rover/curiosity_gazebo/worlds/mars_curiosity.world
+++ b/curiosity_rover/curiosity_gazebo/worlds/mars_curiosity.world
@@ -1,41 +1,67 @@
-<sdf version="1.5">
+<sdf version="1.8">
   <world name="default">
+  
+    <scene>
+      <ambient>0.4 0.4 0.4 1</ambient>
+      <background>0.9 0.753 0.66 1</background>
+      <grid>false</grid>
+    </scene>  
+  
     <gui fullscreen="0">
 
-      <plugin filename="GzScene3D" name="3D View">
-        <ignition-gui>
+      <plugin filename="MinimalScene" name="3D View">
+        <gz-gui>
           <title>3D View</title>
           <property type="bool" key="showTitleBar">false</property>
           <property type="string" key="state">docked</property>
-        </ignition-gui>
+        </gz-gui>
+ 
         <engine>ogre2</engine>
         <scene>scene</scene>
-        <background_color>0.9 0.753 0.66</background_color>
         <camera_pose>-5.0 0.0 -6.0 0.0 0.0 0.0</camera_pose>
       </plugin>
-
-      <plugin filename="ImageDisplay" name="Image Display">
-        <ignition-gui>
+      <plugin filename="GzSceneManager" name="Scene Manager">
+        <gz-gui>
+          <property key="resizable" type="bool">false</property>
+          <property key="width" type="double">5</property>
+          <property key="height" type="double">5</property>
           <property key="state" type="string">floating</property>
-        </ignition-gui>
+          <property key="showTitleBar" type="bool">false</property>
+        </gz-gui>
       </plugin>
+      <plugin filename="InteractiveViewControl" name="Interactive view control">
+        <gz-gui>
+          <property key="resizable" type="bool">false</property>
+          <property key="width" type="double">5</property>
+          <property key="height" type="double">5</property>
+          <property key="state" type="string">floating</property>
+          <property key="showTitleBar" type="bool">false</property>
+        </gz-gui>
+      </plugin>
+ 
+      <plugin filename="ImageDisplay" name="Image Display">
+        <gz-gui>
+          <property key="state" type="string">floating</property>
+        </gz-gui>
+      </plugin> 
+      
     </gui>
 
-    <server_config>
-    <plugins>
-        <plugin entity_name="*"
-                entity_type="world"
-                filename="ignition-gazebo-scene-broadcaster-system"
-                name="ignition::gazebo::systems::SceneBroadcaster">
-        </plugin>
-        <plugin entity_name="*"
-                entity_type="world"
-                filename="ignition-gazebo-sensors-system"
-                name="ignition::gazebo::systems::Sensors">
-        <render_engine>ogre2</render_engine>
-        </plugin>
-    </plugins>
-    </server_config>
+    <plugin
+      filename="gz-sim-physics-system"
+      name="gz::sim::systems::Physics">
+    </plugin>
+
+    <plugin
+      filename="gz-sim-user-commands-system"
+      name="gz::sim::systems::UserCommands">
+    </plugin>
+
+    <plugin
+      filename="gz-sim-scene-broadcaster-system"
+      name="gz::sim::systems::SceneBroadcaster">
+    </plugin> 
+
 
     <light type="directional" name="sun">
       <cast_shadows>true</cast_shadows>
@@ -62,3 +88,4 @@
 
   </world>
 </sdf>
+

--- a/curiosity_rover/curiosity_rover_demo/CMakeLists.txt
+++ b/curiosity_rover/curiosity_rover_demo/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.22)
 project(curiosity_rover_demo)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/curiosity_rover/docker-compose.yml
+++ b/curiosity_rover/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       [
         "bash",
         "-c",
-        "source /opt/ros/humble/setup.bash && source ~/curiosity_ws/install/setup.bash && ros2 launch curiosity_gazebo curiosity_gazebo.launch.py",
+        "source /opt/ros/jazzy/setup.bash && source ~/curiosity_ws/install/setup.bash && ros2 launch curiosity_gazebo curiosity_gazebo.launch.py",
       ]
     network_mode: host
     privileged: true # for UI

--- a/ros_trick/ros_src/trick_ros2_control/src/trick_system.cpp
+++ b/ros_trick/ros_src/trick_ros2_control/src/trick_system.cpp
@@ -102,7 +102,7 @@ hardware_interface::CallbackReturn TrickSystem::on_configure(const rclcpp_lifecy
   incoming_data_thread_ = std::thread([this]() {
     while (rclcpp::ok())
     {
-      if (this->get_state().label() == "active")
+      if (this->get_lifecycle_state().label() == "active")
       {
         std::string incoming_msg;
         this->trick_conn_socket_ >> incoming_msg;


### PR DESCRIPTION
Closes #82.  Tested both in a machine with Jazzy as well as in a standard space-robots docker setup pointing to jazzy-2025.1.0. The only  change that I was slightly unsure was in the rover's control file:

```
    wheel_tree_position_controller:
-      type: effort_controllers/JointGroupPositionController
+      type: effort_controllers/JointGroupEffortController
```

Wheels seem to be moving fine using the standard JointGroupEffortController, unless I am missing observing some expected behavior. Additionally, JointGroupEffortController is defined in a [fork](https://github.com/tonylitianyu/ros2_controllers/tree/effort_group_position_controller_2) of ros2_controllers that is outdated. 


Tested by running both the canadarm and the mars rover simulations, visualizing them in Rviz while  doing the usual motion tests (moving the canadarm to different poses using the demo services; for the mars rover, moving it forward, opening/closing the arm, rotating the mast, visualizing the image display). 
