### PR TITLE
Update Canadarm, Curiosituy Rover demos' Dockerfiles to use Space ROS 2025.04.0 (#97).

### DIFF
--- a/canadarm2/Dockerfile
+++ b/canadarm2/Dockerfile
@@ -1,4 +1,4 @@
-FROM osrf/space-ros:jazzy-2025.01.0
+FROM osrf/space-ros:jazzy-2025.04.0
 
 ENV RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
 ENV ROS_DISTRO=jazzy

--- a/curiosity_rover/Dockerfile
+++ b/curiosity_rover/Dockerfile
@@ -1,4 +1,4 @@
-FROM osrf/space-ros:jazzy-2025.01.0
+FROM osrf/space-ros:jazzy-2025.04.0
 
 ENV RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
 ENV ROS_DISTRO=jazzy


### PR DESCRIPTION
We have now released a new version of Space ROS, tagged jazzy-2025.04.0.

This commit updates the dockerfiles prepared to run with Space ROS Jazzy to use the new release.