### PR TITLE
Closes issue 94

### DIFF
--- a/ros_trick/canadarm_ros_trick_demo.Dockerfile
+++ b/ros_trick/canadarm_ros_trick_demo.Dockerfile
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 # The base image is built from
-# https://github.com/space-ros/docker/blob/humble-2024.10.0/space_robots/
-# Git tag: humble-2024.10.0.
+# https://github.com/space-ros/docker/blob/jazzy-2025.04.0/space_robots/
+# Git tag: jazzy-2025.04.0.
 FROM openrobotics/space_robots_demo:latest
 
 # Rviz does not work inside the newest space_robots_demo, so we have to upgrade

--- a/ros_trick/ros_src/ros_trick_bridge/params/ros_trick_bridge_example_params.yaml
+++ b/ros_trick/ros_src/ros_trick_bridge/params/ros_trick_bridge_example_params.yaml
@@ -2,7 +2,7 @@ ros_trick_bridge:
   ros__parameters:
     sim_directory: /home/spaceros-user/trick_sims/SIM_trick_canadarm
     sim_inputfile: RUN_2DPlanar/input.py
-    sim_executable: S_main_Linux_11.4_x86_64.exe
+    sim_executable: S_main_Linux_13.3_x86_64.exe
     sim_args: ''
     publish_clock: true
     clock_publish_period: 0.02

--- a/ros_trick/ros_trick_bridge.Dockerfile
+++ b/ros_trick/ros_trick_bridge.Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM osrf/space-ros:humble-2024.10.0
+FROM osrf/space-ros:jazzy-2025.04.0
 
 # Install trick dependencies.
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
@@ -45,10 +45,11 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 
 ENV PYTHON_VERSION=3
 
-# Get Trick version 19.7.2 from GitHub, configure and build it.
+# Note: For Jazzy, we need a fix in TRICK to work in 24.04 (commit 4781cfe)
+# there is not yet a tag including the fix commit, checking out the latest one tested to work
 RUN mkdir ${HOME_DIR}/trick
 WORKDIR ${HOME_DIR}/trick
-RUN git clone --branch 19.7.2 --depth 1 https://github.com/nasa/trick.git .
+RUN git clone --branch master https://github.com/nasa/trick.git . && git checkout 1b6d75b
 RUN ./configure && make
 
 # Add ${TRICK_HOME}/bin to the PATH variable.
@@ -70,7 +71,7 @@ RUN rm -rf build log src
 # Install RBDL, which is used for calculating forward dynamics in trick.
 RUN mkdir ${HOME_DIR}/rbdl
 WORKDIR ${HOME_DIR}/rbdl
-RUN git clone --branch v3.3.0 --depth 1 https://github.com/rbdl/rbdl.git . \
+RUN git clone --branch v3.3.1 --depth 1 https://github.com/rbdl/rbdl.git . \
   && git submodule update --init --remote --depth 1 addons/urdfreader/
 RUN   mkdir ./rbdl-build \
   && cd rbdl-build/ \


### PR DESCRIPTION
Small fix to run the tricks demo in Jazzy. Tested with docker (jazzy-25-04). Canadarm moves accordingly using the tricks simulation. Without the changes in this PR the docker image didn't compile  and the launch file for tricks was failing due to the executable's name mismatch.
![Screenshot from 2025-05-01 12-41-20](https://github.com/user-attachments/assets/e35badd6-89e1-4396-b0c1-d724a7078eea)
![Screenshot from 2025-05-01 12-42-24](https://github.com/user-attachments/assets/a382ba7a-31a6-45d3-b71a-dfa0be39c879).

This PR closes issue #94 
