### PR TITLE
`curiosity_rover`: Fix service name in `ros2` call (#157)

### DIFF
--- a/curiosity_rover/README.md
+++ b/curiosity_rover/README.md
@@ -43,7 +43,7 @@ This will start the demo in one terminal and gazebo in another terminal. To cont
     ros2 service call /turn_right std_srvs/srv/Empty
 
     # Stop
-    ros2 service call /stop std_srvs/srv/Empty
+    ros2 service call /move_stop std_srvs/srv/Empty
     ```
 2. To control the arm of the rover, you can run the following services,
     ```bash


### PR DESCRIPTION
The README of the `curiosity_rover` says that the rover can be stopped with:

```
ros2 service call /stop std_srvs/srv/Empty
```

but the service is `/move_stop`.

This commit modifies the README to use the correct service name.

Fixes #157.