### PR TITLE
`lunar_pole_exploration_rover`: Fix container name in `README.md` (#160)

### DIFF
--- a/lunar_pole_exploration_rover/README.md
+++ b/lunar_pole_exploration_rover/README.md
@@ -105,7 +105,7 @@ ros2 launch lunar_pole_exploration_rover lunar_pole_exploration_rover.launch.py
 Open a new terminal and attach the current running container:
 
 ```bash
-docker exec -it lunar_pole_exploration_rover bash
+docker exec -it osrf_lunar_pole_exploration_rover_demo bash
 ```
 
 Source the necessary packages.


### PR DESCRIPTION
The `README.md` of the `lunar_pole_exploration_rover` example states that a container can be launched with:

```
docker exec -it lunar_pole_exploration_rover
```

However, `run.sh` derives the container name from the image name (`osrf/lunar_pole_exploration_rover_demo`, slashes replaced by underscores), so it is actually `osrf_lunar_pole_exploration_rover_demo`. The documented command fails as written.

This commit replaces the container name in the README to match the name used by `run.sh`.

Filed on behalf of @asimonov .

Fixes #160.