### PR TITLE
`lunar_pole_exploration_rover`: Fix and complete documentation of rover commands in README (#162)

### DIFF
--- a/lunar_pole_exploration_rover/README.md
+++ b/lunar_pole_exploration_rover/README.md
@@ -141,7 +141,7 @@ ros2 service call /turn_right std_srvs/srv/Empty
 Rotate in place
 
 ```bash
-ros2 service call /turn_right std_srvs/srv/Empty
+ros2 service call /rotate_on_place std_srvs/srv/Empty
 ```
 
 Rotate the camera

--- a/lunar_pole_exploration_rover/README.md
+++ b/lunar_pole_exploration_rover/README.md
@@ -148,6 +148,32 @@ Rotate in place
 ros2 service call /rotate_on_place std_srvs/srv/Empty
 ```
 
+Move sideways to the left
+
+```bash
+ros2 service call /move_sideway_left std_srvs/srv/Empty
+```
+
+Move sideways to the right
+
+```bash
+ros2 service call /move_sideway_right std_srvs/srv/Empty
+```
+
+Move sideways and turn left at the same time
+
+```bash
+ros2 service call /move_sideway_and_turn_left std_srvs/srv/Empty
+```
+
+The rover can also be driven directly by publishing a velocity command, which
+the `move_wheel` node subscribes to. Linear `x` drives forwards and backwards,
+linear `y` drives sideways, and angular `z` alone rotates the rover in place.
+
+```bash
+ros2 topic pub /cmd_vel geometry_msgs/msg/Twist '{linear: {x: 0.3}, angular: {z: 0.2}}'
+```
+
 Rotate the camera
 
 ```bash

--- a/lunar_pole_exploration_rover/README.md
+++ b/lunar_pole_exploration_rover/README.md
@@ -116,6 +116,10 @@ source ~/demos_ws/install/setup.bash
 
 #### Available commands
 
+Each command sets a motion that continues until another command is issued.
+
+Move the rover forward
+
 ```bash
 ros2 service call /move_forward std_srvs/srv/Empty
 ```


### PR DESCRIPTION
Add missing command name, fix topic name, and add missing commands in `README.md` of the `lunar_pole_exploration_rover` demo.

Fixes #162.